### PR TITLE
Feature/SY/우정테스트prompt수정

### DIFF
--- a/app/prompts/prompts.py
+++ b/app/prompts/prompts.py
@@ -151,46 +151,62 @@ friendship_prompt = """
 4. Who speaks in a more comforting manner? (Expressed as a percentage summing up to 100%)
 5. Who gives a stronger sense of betrayal? (Expressed as a percentage summing up to 100%)
 6. List the top 5 emotions felt by A and B based on their conversation, starting from the strongest.
+7. If the emotion of love is present during the conversation, rigorously assess and indicate the magnitude of love felt by A and B. (Evaluate based on the entire conversation and express the magnitude felt by A and B with scores from 1 to 100 each, with 100 being the highest.)
+7-1. If there is no feeling of love or a score below 50, or if both scores are exactly 50, do not create a 'friendship_likeability'.
 
-##Format json
+##Format JSON
 {
-    "total_score":{
-        "name,":num,
-        "name":num
-    },
-    "sacrifice":{
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        },
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        }
-    },
-    "comfortable":{
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        },
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        }
-    },
-    "betrayer":{
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        },
-        "name":{
-            "score":num,
-            "reason":str (short, a line)
-        }
-    },
-    "Biggest_Sentimental":{
-        "name":{"a","b","c","d","e"},
-        "name":{"a","b","c","d","e"}
-    }
+"friendship_total_score":{
+  "name,":num,
+  "name":num
+},
+
+"friendship_sacrifice":{
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  },
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  }
+},
+
+"friendship_comfortable":{
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  },
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  }
+},
+
+"friendship_betrayer":{
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  },
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  }
+},
+
+"friendship_Biggest_Sentimental":{
+  "name":{"a","b","c","d","e"},
+  "name":{"a","b","c","d","e"}
+},
+
+"friendship_likeability":{
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  },
+  "name":{
+    "score":num,
+    "reason":str (short, a line)
+  }
 }
 """


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
<!-- 작업 중인 브랜치를 알려주세요. -->
- Feature/SY/우정테스트prompt수정

### 💡 작업동기
<!-- 작업 배경을 알려주세요. -->
- 기존 prompt -> 애정도가 높을 경우 연인관계로 발전 가능성을 배제함
- 대화 내용 중 애정도와 관련된 점수가 특정 기준 이상을 넘기면 로딩페이지도 다르게 하여 애정도 테스트로 넘어갈 수 있도록 수정이 필요하다고 판단하여 추가

### 🔑 주요 변경사항
<!-- 주요 변경사항 목록을 알려주세요. -->
- 
[우정 LLM prompt 수정본.txt](https://github.com/user-attachments/files/16154632/LLM.prompt.txt)
*텍스트 파일 참조 - 기존 prompt와 수정된 prompt존재

### 특별히 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 코드 세션 또는 로직을 생성하세요. -->
- 
