### PR TITLE
[Hotfix]/SY/우정테스트prompt수정

### DIFF
--- a/app/prompts/prompts.py
+++ b/app/prompts/prompts.py
@@ -152,8 +152,7 @@ friendship_prompt = """
 5. Who gives a stronger sense of betrayal? (Expressed as a percentage summing up to 100%)
 6. List the top 5 emotions felt by A and B based on their conversation, starting from the strongest.
 7. If the emotion of love is present during the conversation, rigorously assess and indicate the magnitude of love felt by A and B. (Evaluate based on the entire conversation and express the magnitude felt by A and B with scores from 1 to 100 each, with 100 being the highest.)
-7-1. If there is no feeling of love or a score below 50, or if both scores are exactly 50, do not create a 'friendship_likeability' and 'friendship_likeability_script'.
-7-2. If you've felt the emotion of love, select five lines from the entire conversation where you felt that emotion, and rank them based on how strongly you experienced the feeling of love.
+7-1. If you've felt the emotion of love, select five lines from the entire conversation where you felt that emotion, and rank them based on how strongly you experienced the feeling of love.
 
 ##Format JSON
 {
@@ -196,8 +195,8 @@ friendship_prompt = """
 },
 
 "friendship_Biggest_Sentimental":{
-  "name":{"a","b","c","d","e"},
-  "name":{"a","b","c","d","e"}
+  "name":["a","b","c","d","e"],
+  "name":["a","b","c","d","e"]
 },
 
 "friendship_likeability":{
@@ -211,8 +210,8 @@ friendship_prompt = """
   },
 
 "friendship_likeability_script":{
-  "name":{"a","b","c","d","e"},
-  "name":{"a","b","c","d","e"}
+  "name":["a","b","c","d","e"],
+  "name":["a","b","c","d","e"]
   }
 }
 """


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
<!-- 작업 중인 브랜치를 알려주세요. -->
- Hotfix/SY/우정테스트prompt수정

### 💡 작업동기
<!-- 작업 배경을 알려주세요. -->
- 우정테스트 디버깅 중 데이터 형식으로 인한 오류가 발생하여 prompt의 조건과 데이터 형식을 수정

### 🔑 주요 변경사항
<!-- 주요 변경사항 목록을 알려주세요. -->
- prompt 조건 중 7-1. If there is no feeling of love or a score below 50, or if both scores are exactly 50, do not create a 'friendship_likeability' and 'friendship_likeability_script'. 을 삭제
- "friendship_likeability_script"과 "friendship_Biggest_Sentimental"안의 values부분을 {}에서 []로 변경

### 특별히 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 코드 세션 또는 로직을 생성하세요. -->
- 
